### PR TITLE
Fix scale_cross_stitch_pattern value in font.json

### DIFF
--- a/src/abecedaire_small/font.json
+++ b/src/abecedaire_small/font.json
@@ -667,9 +667,5 @@
     "sortable": false,
     "combine_at_sort_indices": [],
     "leading": 106.0,
-<<<<<<< Updated upstream
     "scale_cross_stitch_pattern": true
-=======
-    "scale_cross_stitch_pattern": false
->>>>>>> Stashed changes
 }


### PR DESCRIPTION
Reverted 'scale_cross_stitch_pattern' to true from false.